### PR TITLE
[TS] Refactor svg minification script

### DIFF
--- a/.scripts/svg.js
+++ b/.scripts/svg.js
@@ -1,8 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const execSync = require('child_process').execSync;
-const { optimize } = require('svgo');
-const { parse, stringify } = require('svgson');
+const fs = require("fs");
+const path = require("path");
+const execSync = require("child_process").execSync;
+const { optimize } = require("svgo");
+const { parse, stringify } = require("svgson");
 
 const replaceHexColors = (svgElement) => {
   if (svgElement.attributes) {
@@ -11,7 +11,7 @@ const replaceHexColors = (svgElement) => {
       if (hexColorRegex.test(value)) {
         svgElement.attributes[key] = value.replace(
           hexColorRegex,
-          'currentColor'
+          "currentColor"
         );
       }
     }
@@ -25,11 +25,11 @@ const replaceHexColors = (svgElement) => {
 };
 
 const modifiedFiles = execSync(
-  'git status --porcelain | cut -c 1-3 --complement'
+  "git status --porcelain | cut -c 1-3 --complement"
 )
   .toString()
-  .split('\n')
-  .filter((file) => file.endsWith('.svg'));
+  .split("\n")
+  .filter((file) => file.endsWith(".svg"));
 
 modifiedFiles.forEach((file) => {
   fs.readFile(file, (err, data) => {
@@ -37,27 +37,96 @@ modifiedFiles.forEach((file) => {
 
     const result = optimize(data, {
       path: file,
+      multipass: true,
+      js2svg: {
+        indent: 2,
+        pretty: true,
+      },
       plugins: [
         {
-          name: 'preset-default',
+          name: "convertShapeToPath",
           params: {
-            overrides: {
-              convertColors: false,
-              removeViewBox: false,
-            },
+            convertArcs: true,
           },
         },
-        'convertStyleToAttrs',
-        'removeDimensions',
-        'removeScriptElement',
-        'removeStyleElement',
+        {
+          name: "removeAttrs",
+          params: {
+            attrs: "(stroke)",
+          },
+        },
+        {
+          name: "convertColors",
+          params: {
+            currentColor: true,
+          },
+        },
+        {
+          name: "cleanupNumericValues",
+          params: {
+            floatPrecision: 2
+          }
+        },
+        {
+          name: "convertPathData",
+          params: {
+            floatPrecision: 2
+          }
+        },
+        {
+          name: "convertTransform",
+          params: {
+            floatPrecision: 2
+          }
+        },
+        {
+          name: "cleanupListOfValues",
+          params: {
+            floatPrecision: 2
+          }
+        },
+        "reusePaths",
+        "removeDoctype",
+        "removeXMLProcInst",
+        "removeMetadata",
+        "removeEditorsNSData",
+        "cleanupAttrs",
+        "mergeStyles",
+        "inlineStyles",
+        "convertStyleToAttrs",
+        "cleanupIds",
+        "removeUselessDefs",
+        "removeUnknownsAndDefaults",
+        "removeNonInheritableGroupAttrs",
+        "removeUselessStrokeAndFill",
+        "cleanupEnableBackground",
+        "removeHiddenElems",
+        "removeEmptyText",
+        "convertShapeToPath",
+        "moveElemsAttrsToGroup",
+        "moveGroupAttrsToElems",
+        "collapseGroups",
+        "convertEllipseToCircle",
+        "convertTransform",
+        "removeEmptyAttrs",
+        "removeEmptyContainers",
+        "mergePaths",
+        "mergePaths",
+        "removeUnusedNS",
+        "sortDefsChildren",
+        "removeTitle",
+        "removeDesc",
+        "removeDimensions",
+        "removeScriptElement",
+        "removeStyleElement",
       ],
     });
+
     parse(result.data, {
       camelcase: true,
     }).then((svgTree) => {
-      let className = path.basename(file).split('.svg').join('');
-      if (file.indexOf('categories') !== -1) {
+      let className = path.basename(file).split(".svg").join("");
+      if (file.indexOf("categories") !== -1) {
         className = `cat-${className}`;
       }
 
@@ -66,7 +135,7 @@ modifiedFiles.forEach((file) => {
         class: `Icon Icon-${className}`,
       };
 
-      replaceHexColors(svgTree);
+      // replaceHexColors(svgTree);
 
       const updatedSvgContent = stringify(svgTree);
       fs.writeFile(file, updatedSvgContent, (err) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opositatest/design-tokens",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "OpositaTest design tokens",
     "homepage": "https://github.com/opositatest/design-tokens#readme",
     "bugs": "https://github.com/opositatest/design-tokens/issues",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "main": "dist/designTokens.js",
     "scripts": {
         "test": "jest",
-        "task-minify": "node ./.scripts/svg.js",
-        "minify:svg": "npm run task-minify && npm run task-minify",
+        "minify:svg": "node ./.scripts/svg.js",
         "build": "node ./.scripts/build.js",
         "publish:github": "npm publish --ignore-scripts --registry='https://npm.pkg.github.com'",
         "prepublishOnly": "npm run test && npm run build",


### PR DESCRIPTION
Tarea: [Refactor script de minificación de SVGs](https://kanbanflow.com/t/r66cYvE1)

## Qué se hizo
- Se refactorizó el script de minificación de svgs, para que en una pasada minfique correctamente los svgs modificado

## Cómo probarlo
- Sobreescribir un icono con el original de figma, lanzar la tarea _npm run minify:svg_, y comprobar que svg se minifica correctamente y se sigue visualizando bien